### PR TITLE
ensure block names are all ASCII characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ complextype | complex SV classification
 num_sv | number of simple SVs + complex SV breakpoints in this call
 bp | all breakpoints, i.e. boundaries of the blocks in the "reference" column (including the flanking blocks)
 bp_uncertainty | width of the uncertainty interval around each breakpoint in `bp`. For odd widths, there is 1 bp more uncertainty on the right side of the breakpoint
-reference | configuration of genomic blocks in the reference
+reference | configuration of genomic blocks in the reference. Blocks are named A through Z, then a through z, then A1 through Z1, etc.
 rearrangement | predicted configuration of genomic blocks in the sample. Inverted blocks are followed by a tick mark, e.g., A', and insertions are represented by underscores _
 len_affected | length of reference sequence affected by this rearrangement  (plus the length of any novel insertions). For complex SVs with no novel insertions, this is often smaller than maxbp - minbp, i.e., the "span" of the rearrangement in the reference
 filter | currently, this is `INSERTION` if there is an insertion present, otherwise `PASS`

--- a/arcsv/constants.py
+++ b/arcsv/constants.py
@@ -22,7 +22,3 @@ RIGHT = 1
 # Soft-clip stuff
 CIGAR_SOFT_CLIP = 4                  # http://pysam.readthedocs.io/en/latest/api.html
 LOWQUAL_CHARS = ('#', '!', '"')
-
-# Insertion symbol in rearrangement strings
-DE_NOVO_SYMBOL = '_'
-TRANSLOCATION_SYMBOL = '='

--- a/arcsv/filter_output.py
+++ b/arcsv/filter_output.py
@@ -2,7 +2,7 @@ import os
 import re
 import sys
 
-from arcsv.constants import DE_NOVO_SYMBOL
+from arcsv.helper import DE_NOVO_CHAR
 
 
 sv_type_dict = {'DEL': 'deletions', 'INV': 'inversions', 'DUP': 'tandemdups',
@@ -140,7 +140,7 @@ def apply_filters(opts, records, header):
         sv_types_long = set(sv_type_dict[x] for x in sv_types_short)
         # complex insertions are still considered insertions
         rearrangement = sv[col_lookup['rearrangement']]
-        if DE_NOVO_SYMBOL in rearrangement:
+        if DE_NOVO_CHAR in rearrangement:
             sv_types_long.add('insertions')
         # compound het?
         sv_id = sv[col_lookup['id']]

--- a/arcsv/sv_affected_len.py
+++ b/arcsv/sv_affected_len.py
@@ -18,6 +18,7 @@ def sv_affected_len(path, blocks):
         if i % 2 == 1:          # forward orientation
             path_string += chr(ord('A') + block_num)
         else:                   # reverse orientation
+            # FIXME: replace 1000 with MAX_BLOCKS constant
             path_string += chr(ord('A') + block_num + 1000)
     print('path_string: {0}'.format(path_string))
 

--- a/arcsv/sv_call_viz.py
+++ b/arcsv/sv_call_viz.py
@@ -9,7 +9,7 @@ from matplotlib.cm import jet
 from matplotlib.collections import PatchCollection
 from matplotlib.patches import Polygon
 
-from arcsv.helper import GenomeInterval
+from arcsv.helper import GenomeInterval, block_idx_to_name
 
 PHI = 1.618
 
@@ -82,7 +82,7 @@ def write_block_labels(text_coords, path, blocks, start):
         if blocks[block].is_insertion():
             letter = '='
         else:
-            letter = chr(65 + block - start)
+            letter = block_idx_to_name(block - start)
         txt = plt.text(x, y, letter,
                        color='white', size=25, ha='center', va='center')
         txt.set_path_effects([path_effects.Stroke(linewidth=3, foreground='black'),

--- a/arcsv/sv_classify.py
+++ b/arcsv/sv_classify.py
@@ -96,6 +96,7 @@ def classify_paths(path1, path2, blocks, num_genome_blocks, left_bp, right_bp, v
     start_pos = blocks[floor(path1[0] / 2)].start
     end_pos = blocks[floor(path1[-1] / 2)].end
     # @ here is the ASCII character before A,B,C,... (see below)
+    # FIXME: this doesn't work with 26+ events in a single complex SV
     ev_id = '{0},{1}-{2},@'.format(chrom, start_pos + 1, end_pos)  # 1-indexed, inclusive interval for VCF
     ev1, sv1 = classify_svs(path1, blocks, num_genome_blocks, left_bp, right_bp, verbosity)
     ev2, sv2 = classify_svs(path2, blocks, num_genome_blocks, left_bp, right_bp, verbosity)

--- a/arcsv/sv_inference.py
+++ b/arcsv/sv_inference.py
@@ -10,7 +10,7 @@ from collections import Counter
 from math import log, floor
 
 from arcsv.constants import ALTERED_QNAME_MAX_LEN
-from arcsv.helper import GenomeInterval, path_to_string, \
+from arcsv.helper import GenomeInterval, block_idx_to_name, path_to_string, \
     is_path_ref, flip_parity, is_adj_satisfied, get_block_distances_between_nodes
 from arcsv.sv_call_viz import plot_rearrangement
 from arcsv.sv_classify import classify_paths
@@ -327,7 +327,7 @@ def do_inference(opts, reference_files, g, blocks,
             print('[inference] informative reads: {0}'.format(len(inf_reads)))
             print('[inference] blocks:')
             for i in range(0, end - start + 1):
-                print('\t{0}: {1}-{2}'.format(chr(65 + i),
+                print('\t{0}: {1}-{2}'.format(block_idx_to_name(i),
                                               blocks[start + i].start,
                                               blocks[start + i].end))
             print('')


### PR DESCRIPTION
Previously we named blocks A, B, C, D, etc. but very high-numbered blocks would get unicode characters. This caused the issue here: https://github.com/SUwonglab/arcsv/issues/4

We now name blocks A-Z, a-z, followed by A1, B1, etc.